### PR TITLE
Assignment submission

### DIFF
--- a/deploy/kubernetes/autoscaling/front-end-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/front-end-hsc.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: front-end
-  namespace: sock-shop
+  namespace: microservices-demo
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1

--- a/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
@@ -54,13 +54,13 @@ spec:
           name: tmp-volume
         livenessProbe:
           httpGet:
-            path: /healthZZZZZZZ
+            path: /health
             port: {{ .Values.carts.containerPort }}
           initialDelaySeconds: 420
           periodSeconds: 3
         readinessProbe:
           httpGet:
-            path: /healthZZZZZZ
+            path: /health
             port: {{ .Values.carts.containerPort }}
           initialDelaySeconds: 360
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
@@ -19,5 +19,5 @@ spec:
       - name: load-test
         image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.loadtest.image.repo }}:{{ .Values.loadtest.image.tag }}
         command: ["/bin/sh"]
-        args: ["-c", "while true; do locust --host http://front-end.sock-shop.svc.cluster.local -f /config/locustfile.py --clients 5 --hatch-rate 5 --num-request 100 --no-web; done"]
+        args: ["-c", "while true; do locust --host http://front-end.{{ .Release.Namespace }}.svc.cluster.local -f /config/locustfile.py --clients 5 --hatch-rate 5 --num-request 100 --no-web; done"]
 {{- end }}

--- a/deploy/kubernetes/helm-chart/templates/user-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-dep.yaml
@@ -27,14 +27,14 @@ spec:
         args:
         - -port={{ .Values.user.containerPort }}
         - -database=mongodb
-        - -mongo-host=user-db.{{ .Release.Namespace }}.svc.cluster.local:27016
+        - -mongo-host=$(MONGO_HOST)
         resources:
 {{ toYaml .Values.user.resources | indent 10 }}
         ports:
         - containerPort: {{ .Values.user.containerPort }}
         env:
         - name: MONGO_HOST
-          value: user-db:27017
+          value: user-db.{{ .Release.Namespace }}.svc.cluster.local:27017
         {{- if .Values.zipkin.enabled }}
         - name: ZIPKIN
           value: http://{{ .Values.zipkin.url }}:9411/api/v1/spans


### PR DESCRIPTION
## Task 1

Traefik was installed using a Helm chart. The command used to provision it was:
```sh
helm upgrade --install traefik \
    --namespace kube-ingress \
    --set rbac.enabled=true \`
    --set service.spec.loadBalancerIP=34.136.78.189 \
    --set middlewares.namespace=microservices-demo \
    --set selector.tier=front-end \
    --set="additionalArguments={--log.level=DEBUG, --serversTransport.insecureSkipVerify=true}" \
    traefik/traefik \
    --version 10.7.1
```

## Task 2
The command used was:
```sh
helm install --namespace microservices-demo --create-namespace helm-chart deploy/kubernetes/helm-chart
```

## Task 3

The two issue I identified were:
1. The URLs used for the `liveliness` and `readiness` probes was wrong. I changed it to `health` for both.
2. The port specified under the `mongo-host` argument was wrong.

## Task 4

I chose to set an HPA for `front-end`. In order to make it work I set the namespace to `microservices-demo` and updated the `loadtest-dep.yml` as well. In order to run the load test I also changed the value of `loadtest.enabled` to `true` in the `variable.yaml` file.